### PR TITLE
set last prob to 0 if range ends at 1950.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,5 +18,5 @@ Imports:
 Suggests: knitr,
     testthat
 VignetteBuilder: knitr
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 Encoding: UTF-8

--- a/R/oxcAARCalibratedDate.R
+++ b/R/oxcAARCalibratedDate.R
@@ -101,6 +101,11 @@ plotoxcAARDateSystemGraphics <- function(x, ...){
 
   if (prob_present){
     years <- x$raw_probabilities$dates
+
+    if(max(years) == 1950.5){
+      x$raw_probabilities$probabilities[length(x$raw_probabilities$probabilities)] <- 0
+    }
+
     probability <- x$raw_probabilities$probabilities
     unmodelled_color <- "lightgrey"
     max_prob <- max(probability)


### PR DESCRIPTION
The base plots of calibrated dates are disturbed as soon as the calibrated range hit's 1950 and the probability is not 0 at this time; e.g.
```R
cal <- oxcalCalibrate(200, 35, "LAB")
plot(cal)
```
results in:
![Rplot](https://user-images.githubusercontent.com/6630811/65627413-a0c4ff00-dfcf-11e9-8a19-db28a48d0405.jpeg)

I suggest to set the last value of the raw_probabilities to 0 if a calibrated date 'hit's' 1950.5. With that fix (?) output looks like:
![Rplot01](https://user-images.githubusercontent.com/6630811/65627501-cce08000-dfcf-11e9-9ef5-1fe2ef22990c.jpeg)

Alternatively one might think of adding a value at `year` 1951(?) and set its probability to 0.

@MartinHinz What do you think?

