### PR TITLE
Quickfix download and cran checks

### DIFF
--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -81,7 +81,7 @@ quickSetupOxcal <- function(os = Sys.info()["sysname"], path = tempdir()){
 
   # set path
   test <- tryCatch(setOxcalExecutablePath(exe),
-                   condition=function(e) {
+                   error=function(e) {
                      message("The Oxcal executable path could not be set:")
                      message(e)
                      message("\nIf you received an internet connection error before, please resolve it and try again later")
@@ -101,7 +101,7 @@ downloadOxcal <- function(path = ".") {
   temp <- tempfile()
 
   test <- tryCatch(utils::download.file("https://c14.arch.ox.ac.uk/OxCalDistribution.zip", temp),
-            condition=function(e) {
+            warning=function(e) {
               message("Error Downloading OxCalDistribution.zip:")
               message(e)
               message("\nNo internet connection or data source broken?")

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -89,10 +89,19 @@ quickSetupOxcal <- function(os = Sys.info()["sysname"], path = tempdir()){
 ## ---------- private ----------
 downloadOxcal <- function(path = ".") {
   temp <- tempfile()
-  utils::download.file("https://c14.arch.ox.ac.uk/OxCalDistribution.zip", temp)
-  utils::unzip(temp, exdir = path)
-  unlink(temp)
-  message("Oxcal download to ", normalizePath(path), " successful!")
+
+  test <- tryCatch(utils::download.file("https://c14.arch.ox.ac.uk/OxCalDistribution.zip", temp),
+            condition=function(e) {
+              message("Error Downloading OxCalDistribution.zip:")
+              message(e)
+              message("\nNo internet connection or data source broken?")
+            }
+  )
+  if (!is.null(test) && test==0) {
+    utils::unzip(temp, exdir = path)
+    unlink(temp)
+    message("Oxcal stored successful at ", normalizePath(path), "!")
+  }
 }
 
 getOxcalExecutablePath <- function() {

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -80,7 +80,17 @@ quickSetupOxcal <- function(os = Sys.info()["sysname"], path = tempdir()){
   Sys.chmod(exe, mode = "0777")
 
   # set path
-  setOxcalExecutablePath(exe)
+  test <- tryCatch(setOxcalExecutablePath(exe),
+                   condition=function(e) {
+                     message("The Oxcal executable path could not be set:")
+                     message(e)
+                     message("\nIf you received an internet connection error before, please resolve it and try again later")
+                   }
+  )
+  if (!is.null(test) && test==0) {
+    message("Oxcal Setup successful!")
+  }
+
 
   return()
 }

--- a/tests/testthat/test_utility_functions.R
+++ b/tests/testthat/test_utility_functions.R
@@ -27,6 +27,7 @@ test_that("setOxcalExecutablePath complains when file does not exists",{
 
 context("quickSetupOxcal")
 test_that("quickSetupOxcal downloads oxcal and sets correct path",{
+  skip_on_cran()
   expect_error(quickSetupOxcal(), NA)
   expect_true(dir.exists(paste0(tempdir(), "/OxCal/bin/")))
   expect_true(basename(options("oxcAAR.oxcal_path")[[1]]) %in% c("OxCalLinux",


### PR DESCRIPTION
We were asked to make the quicksetup function fail graceful if oxcal is not downloadable. I implemented the required features, as described in #43, in this branch.