### PR TITLE
Allow to select the output directory of executeOxcalScript() (fixes #42)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,5 +23,5 @@ Suggests: knitr,
     ggridges,
     methods
 VignetteBuilder: knitr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.1
 Encoding: UTF-8

--- a/R/executeOxcalScript.R
+++ b/R/executeOxcalScript.R
@@ -3,13 +3,22 @@
 #' Takes an Oxcal Script, hands it over to oxcal and receives the output that is read from the output file
 #'
 #' @param oxcal_script A string containing the Oxcal commands that should be processed.
+#' @param file A string naming a file for writing. Elements of the path other
+#'  than the last will be created if needed. If `NULL` (the default),
+#'  a temporary file will be used.
 #' @return The path to the js output file
 #'
 #' @author Martin Hinz
 #' @export
-executeOxcalScript <- function(oxcal_script) {
+executeOxcalScript <- function(oxcal_script, file = NULL) {
     oxcal_path <- getOxcalExecutablePath()
-    option_file <- tempfile()
+    if (is.null(file)) {
+      option_file <- tempfile()
+    } else {
+      option_dir <- dirname(file)
+      if (!dir.exists(option_dir)) dir.create(option_dir, recursive = TRUE)
+      option_file <- file
+    }
     output_file <- paste(option_file, ".js", sep = "")
     cat(oxcal_script, file = option_file)
     suppressWarnings(system(paste(shQuote(normalizePath(oxcal_path)), option_file)))

--- a/man/executeOxcalScript.Rd
+++ b/man/executeOxcalScript.Rd
@@ -4,10 +4,14 @@
 \alias{executeOxcalScript}
 \title{Executes an Oxcal Script}
 \usage{
-executeOxcalScript(oxcal_script)
+executeOxcalScript(oxcal_script, file = NULL)
 }
 \arguments{
 \item{oxcal_script}{A string containing the Oxcal commands that should be processed.}
+
+\item{file}{A string naming a file for writing. Elements of the path other
+than the last will be created if needed. If `NULL` (the default),
+a temporary file will be used.}
 }
 \value{
 The path to the js output file


### PR DESCRIPTION
This should allow to choose where to write the output files (fixes #42).

``` r
my_oxcal_code <- ' Plot()
 {
  Sequence("Sequence1")
  {
   Boundary("Beginn");
   Phase("Phase1")
   {
    R_Date("Lab-1",5000,25);
    R_Date("Lab-2",4900,37);
   };
   Boundary("Between");
   Phase("Phase2")
   {
    R_Date("Lab-3",4800,43);
   };
   Boundary("End");
  };
 };'

# Write files named "results" in the working directory
my_result_file <- executeOxcalScript(my_oxcal_code, file = "results")

# Write files in the "here" directory (will be created if it does not exist) in the user home
my_result_file <- executeOxcalScript(my_oxcal_code, file = "~/here/results")
```
